### PR TITLE
(chore): bump `template-resolver` to `0.4.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@fern-api/sdk",
-    "version": "0.8.0",
+    "version": "0.9.0",
     "private": false,
     "repository": "https://github.com/fern-api/fern-typescript",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "node-fetch": "2.7.0",
         "qs": "6.11.2",
         "js-base64": "3.7.2",
-        "@fern-api/template-resolver": "0.3.0"
+        "@fern-api/template-resolver": "0.4.0"
     },
     "devDependencies": {
         "@types/url-join": "4.0.1",


### PR DESCRIPTION
This bump to `0.4.0` fixes handling optional enum parameters when resolving templates. 